### PR TITLE
Avoid using a string replace on stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,16 +21,13 @@ Error.extend = function(subTypeName, errorCode /*optional*/) {
 			return new SubType(message);
 		}
 		
-		//include stack trace in error object
-		Error.captureStackTrace(this, this.constructor);
-		
 		//populate error details
 		this.name = subTypeName; 
 		this.code = errorCode;
 		this.message = message || '';
 		
-		//fix the error message in trace 
-		this.stack = this.stack.replace('Error', this.toString());
+		//include stack trace in error object
+		Error.captureStackTrace(this, this.constructor);
 	});
 	
 	//inherit the base prototype chain


### PR DESCRIPTION
By ensuring the stack gets built after other stack data is populated, this patch results in a cleaner `console.log` output, retains the correct stack output, and avoids having to do a string replace.

**Test code**

``` js
require('./index.js');
var TestError = Error.extend('TestError');
var err = new TestError('watcha');
console.log(err);
console.log();
console.log(err.stack);
```

**Before patch**

```
$ node test.js
{ [TestError: watcha]
  stack: 'TestError: \'watcha\'\n    at Object.<anonymous> (/home/mal/code/extend-error/test.js:5:11)\n    at Module._compile (module.js:449:26)\n    at Object.Module._extensions..js (module.js:467:10)\n    at Module.load (module.js:349:32)\n    at Function.Module._load (module.js:305:12)\n    at Function.Module.runMain (module.js:490:10)\n    at startup (node.js:124:16)\n    at node.js:807:3',
  name: 'TestError',
  code: undefined,
  message: 'watcha' }

TestError: 'watcha'
    at Object.<anonymous> (/home/mal/code/extend-error/test.js:5:11)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:349:32)
    at Function.Module._load (module.js:305:12)
    at Function.Module.runMain (module.js:490:10)
    at startup (node.js:124:16)
    at node.js:807:3
```

**After patch**

```
$ node test.js
{ [TestError: watcha] name: 'TestError', code: undefined, message: 'watcha' }

TestError: watcha
    at Object.<anonymous> (/home/mal/code/extend-error/test.js:5:11)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:349:32)
    at Function.Module._load (module.js:305:12)
    at Function.Module.runMain (module.js:490:10)
    at startup (node.js:124:16)
    at node.js:807:3
```
