### PR TITLE
Configure SubType via object with more customizations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+	"env": {
+		"node": true
+	},
+	"rules": {
+		"no-use-before-define": [2, "nofunc"],
+		"quotes": [2, "single", "avoid-escape"]
+	}
+}

--- a/README.md
+++ b/README.md
@@ -16,19 +16,23 @@ throw MyError('wow')
 npm install extend-error
 ```
 
-and in your app.js, just ```require('extend-error')```. It will provide you an extend() method for the Error type.
-
-
+and in your app.js, just ```require('extend-error').polyfill()```. It will provide you an extend() method for the Error type.
 
 ### syntax
 - extend() takes two arguments : subTypeName & errorCode [optional]
 - it returns the newly created error type
 
+#### polyfilling
+
+All of the examples here assume you ran `polyfill()`. If you're not comfortable with modifying native objects, you can use `extendError()` directly.
+
+```
+var extendError = require('extend-error');
+var ClientError = extendError('ClientError', 400);
+var HttpNotFound = extendError(ClientError, HttpNotFound, 404);
+```
 
 ### more examples for a web app
-
-
-something useful
 
 ```
 var AppError = Error.extend('AppError', 500);
@@ -67,7 +71,7 @@ throw an error in controller
 ```
 var err = HttpNotFound('user profile not found');
 
-throw err; 
+throw err;
 (or)
 callback(err)
 ```
@@ -85,4 +89,3 @@ if (err instanceof ClientError) {
 }
 
 ```
-

--- a/package.json
+++ b/package.json
@@ -11,9 +11,13 @@
     "mocha": "*"
   },
   "repository": {
-    "type" : "git",
-    "url" : "http://github.com/jayyvis/extend-error.git"
+    "type": "git",
+    "url": "http://github.com/jayyvis/extend-error.git"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "lodash.clonedeep": "~3.0.0",
+    "lodash.forown": "~3.0.1",
+    "lodash.identity": "~3.0.0"
+  }
 }
-

--- a/test-fixtures/http-errors-functional.js
+++ b/test-fixtures/http-errors-functional.js
@@ -5,17 +5,47 @@ var extendError = require('..');
 /**
  * thrown when there is an app related error
  */
-exports.AppError = extendError('AppError', 500);
+exports.AppError = extendError({
+	subTypeName: 'AppError',
+	properties: {
+		code: 500
+	}
+});
 
 /**
  * thrown when there is error in client request/data
  */
-var ClientError = exports.ClientError = extendError(Error, 'ClientError', 400);
+var ClientError = exports.ClientError = extendError(Error, {
+	subTypeName: 'ClientError',
+	properties: {
+		code: 400
+	}
+});
 
 /**
  * specific http error types
  */
-exports.HttpNotFound = extendError(ClientError, 'HttpNotFound', 404);
-exports.HttpUnauthorized = extendError(ClientError, 'HttpUnauthorized', 401);
-exports.HttpForbidden = extendError(ClientError, 'HttpForbidden', 403);
-exports.HttpConflict = extendError(ClientError, 'HttpConflict', 409); //unique constraint error
+exports.HttpNotFound = extendError(ClientError, {
+	subTypeName: 'HttpNotFound',
+	properties: {
+		code: 404
+	}
+});
+exports.HttpUnauthorized = extendError(ClientError, {
+	subTypeName: 'HttpUnauthorized',
+	properties: {
+		code: 401
+	}
+});
+exports.HttpForbidden = extendError(ClientError, {
+	subTypeName: 'HttpForbidden',
+	properties: {
+		code: 403
+	}
+});
+exports.HttpConflict = extendError(ClientError, {
+	subTypeName: 'HttpConflict',
+	properties: {
+		code: 409
+	}
+}); //unique constraint error

--- a/test-fixtures/http-errors-functional.js
+++ b/test-fixtures/http-errors-functional.js
@@ -1,0 +1,21 @@
+/** few custom error types required for web apps **/
+
+var extendError = require('..');
+
+/**
+ * thrown when there is an app related error
+ */
+exports.AppError = extendError('AppError', 500);
+
+/**
+ * thrown when there is error in client request/data
+ */
+var ClientError = exports.ClientError = extendError(Error, 'ClientError', 400);
+
+/**
+ * specific http error types
+ */
+exports.HttpNotFound = extendError(ClientError, 'HttpNotFound', 404);
+exports.HttpUnauthorized = extendError(ClientError, 'HttpUnauthorized', 401);
+exports.HttpForbidden = extendError(ClientError, 'HttpForbidden', 403);
+exports.HttpConflict = extendError(ClientError, 'HttpConflict', 409); //unique constraint error

--- a/test-fixtures/http-errors-monkeypatched.js
+++ b/test-fixtures/http-errors-monkeypatched.js
@@ -5,18 +5,48 @@ require('..').monkeypatch();
 /**
  * thrown when there is an app related error
  */
-exports.AppError = Error.extend('AppError', 500);
+exports.AppError = Error.extend({
+	subTypeName: 'AppError',
+	properties: {
+		code: 500
+	}
+});
 
 
 /**
  * thrown when there is error in client request/data
  */
-var ClientError = exports.ClientError = Error.extend('ClientError', 400);
+var ClientError = exports.ClientError = Error.extend({
+	subTypeName: 'ClientError',
+	properties: {
+		code: 400
+	}
+});
 
 /**
  * specific http error types
  */
-exports.HttpNotFound = ClientError.extend('HttpNotFound', 404);
-exports.HttpUnauthorized = ClientError.extend('HttpUnauthorized', 401);
-exports.HttpForbidden = ClientError.extend('HttpForbidden', 403);
-exports.HttpConflict = ClientError.extend('HttpConflict', 409); //unique constraint error
+exports.HttpNotFound = ClientError.extend({
+	subTypeName: 'HttpNotFound',
+	properties: {
+		code: 404
+	}
+});
+exports.HttpUnauthorized = ClientError.extend({
+	subTypeName: 'HttpUnauthorized',
+	properties: {
+		code: 401
+	}
+});
+exports.HttpForbidden = ClientError.extend({
+	subTypeName: 'HttpForbidden',
+	properties: {
+		code: 403
+	}
+});
+exports.HttpConflict = ClientError.extend({
+	subTypeName: 'HttpConflict',
+	properties: {
+		code: 409
+	}
+}); //unique constraint error

--- a/test-fixtures/http-errors-monkeypatched.js
+++ b/test-fixtures/http-errors-monkeypatched.js
@@ -1,10 +1,9 @@
 /** few custom error types required for web apps **/
 
-require('./index.js');
-
+require('..').monkeypatch();
 
 /**
- * thrown when there is an app related error 
+ * thrown when there is an app related error
  */
 exports.AppError = Error.extend('AppError', 500);
 
@@ -14,7 +13,6 @@ exports.AppError = Error.extend('AppError', 500);
  */
 var ClientError = exports.ClientError = Error.extend('ClientError', 400);
 
-
 /**
  * specific http error types
  */
@@ -22,5 +20,3 @@ exports.HttpNotFound = ClientError.extend('HttpNotFound', 404);
 exports.HttpUnauthorized = ClientError.extend('HttpUnauthorized', 401);
 exports.HttpForbidden = ClientError.extend('HttpForbidden', 403);
 exports.HttpConflict = ClientError.extend('HttpConflict', 409); //unique constraint error
-
-

--- a/test-fixtures/http-errors-previousformat.js
+++ b/test-fixtures/http-errors-previousformat.js
@@ -1,0 +1,22 @@
+/** few custom error types required for web apps **/
+
+require('..').monkeypatch();
+
+/**
+ * thrown when there is an app related error
+ */
+exports.AppError = Error.extend('AppError', 500);
+
+
+/**
+ * thrown when there is error in client request/data
+ */
+var ClientError = exports.ClientError = Error.extend('ClientError', 400);
+
+/**
+ * specific http error types
+ */
+exports.HttpNotFound = ClientError.extend('HttpNotFound', 404);
+exports.HttpUnauthorized = ClientError.extend('HttpUnauthorized', 401);
+exports.HttpForbidden = ClientError.extend('HttpForbidden', 403);
+exports.HttpConflict = ClientError.extend('HttpConflict', 409); //unique constraint error

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,7 @@ describe('functional', function() {
 describe('monkeypatched', function() {
 	var errors = require('../test-fixtures/http-errors-monkeypatched');
 	tests(errors);
-	assert.ok(typeof errors.ClientError.extend === 'function', 'ClientError does not have an extend method');
+	assert.ok(typeof errors.ClientError.extend === 'function', 'ClientError has an extend method');
 });
 
 function tests(errors) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,60 +1,72 @@
+'use strict';
+
 /**
  * mocha test cases
  */
 
-var errors = require('../http-errors');
+/* eslint-env mocha */
 
 var assert = require('assert');
 
-
-describe('instantiation', function() {
-	it('should work with new operator', function() {
-		var err = new errors.AppError('problem');
-		assert.ok(err instanceof errors.AppError);
-	});
-	
-	it('should work without new operator', function() {
-		var err = errors.AppError('problem');
-		assert.ok(err instanceof errors.AppError);
-	});
+describe('functional', function() {
+	var errors = require('../test-fixtures/http-errors-functional');
+	tests(errors);
+	assert.ok(typeof errors.ClientError.extend === 'undefined', 'ClientError does not have an extend method');
 });
 
-
-describe('inheritance', function() {
-	it('should maintain prototype hierarchy with one level', function() {
-		var err = new errors.ClientError('email required');
-		
-		assert.ok(err instanceof errors.ClientError, 'ClientError is not an instance of ClientError');
-		assert.ok(err instanceof Error, 'ClientError is not an instance of Error');
-	});
-	
-	it('should maintain prototype hierarchy with two levels', function() {
-		var notfound = new errors.HttpNotFound('item not found');
-		
-		assert.ok(notfound instanceof errors.HttpNotFound, 'HttpNotFound is not an instance of HttpNotFound');
-		assert.ok(notfound instanceof errors.ClientError, 'HttpNotFound is not an instance of ClientError');
-		assert.ok(notfound instanceof Error, 'HttpNotFound is not an instance of Error');
-	});
+describe('monkeypatched', function() {
+	var errors = require('../test-fixtures/http-errors-monkeypatched');
+	tests(errors);
+	assert.ok(typeof errors.ClientError.extend === 'function', 'ClientError does not have an extend method');
 });
 
+function tests(errors) {
+	describe('instantiation', function() {
+		it('should work with new operator', function() {
+			var err = new errors.AppError('problem');
+			assert.ok(err instanceof errors.AppError);
+		});
 
-describe('error details', function() {
-	it('should have message', function() {
-		var err;
-		
-		err = new errors.ClientError('name required');
-		assert.equal(err.message, 'name required');
-		
-		err = new errors.ClientError();
-		assert.equal(err.message, '');
+		it('should work without new operator', function() {
+			/* eslint new-cap: [0] */
+			var err = errors.AppError('problem');
+			assert.ok(err instanceof errors.AppError);
+		});
 	});
-	
-	it('should have code', function() {
-		var err = new errors.ClientError();
-		assert.equal(err.code, 400);
+
+	describe('inheritance', function() {
+		it('should maintain prototype hierarchy with one level', function() {
+			var err = new errors.ClientError('email required');
+
+			assert.ok(err instanceof errors.ClientError, 'ClientError is not an instance of ClientError');
+			assert.ok(err instanceof Error, 'ClientError is not an instance of Error');
+		});
+
+		it('should maintain prototype hierarchy with two levels', function() {
+			var notfound = new errors.HttpNotFound('item not found');
+
+			assert.ok(notfound instanceof errors.HttpNotFound, 'HttpNotFound is not an instance of HttpNotFound');
+			assert.ok(notfound instanceof errors.ClientError, 'HttpNotFound is not an instance of ClientError');
+			assert.ok(notfound instanceof Error, 'HttpNotFound is not an instance of Error');
+		});
 	});
-	
-});
 
 
+	describe('error details', function() {
+		it('should have message', function() {
+			var err;
 
+			err = new errors.ClientError('name required');
+			assert.equal(err.message, 'name required');
+
+			err = new errors.ClientError();
+			assert.equal(err.message, '');
+		});
+
+		it('should have code', function() {
+			var err = new errors.ClientError();
+			assert.equal(err.code, 400);
+		});
+
+	});
+}

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,11 @@ describe('monkeypatched', function() {
 	assert.ok(typeof errors.ClientError.extend === 'function', 'ClientError has an extend method');
 });
 
+describe('compatibility', function() {
+	var errors = require('../test-fixtures/http-errors-previousformat');
+	tests(errors);
+});
+
 function tests(errors) {
 	describe('instantiation', function() {
 		it('should work with new operator', function() {


### PR DESCRIPTION
Still needs some tests, but much more robust than #4.
1. `extend()` now accepts an options object as alternative to the `subTypeName` and `errorCode` parameters.
2. Decreases emphasis on HTTP-related errors. (instead of passing `errorCode`, add `{properties: {code: <code>}}` to the `options` object.
3. Adds ability to provide alternate `toString()`.
4. Adds `parseFn()`, which can do additional processing on the SubType constructor argument. I'm primarily envisioning it as a way to wrap http error responses with an Error:
   
   ``` JavaScript
   if (res.statusCode === 404) {
     throw new HttpNotFoundError(res);
   }
   ```
5. Just like #4, makes monkeypatching optional.
